### PR TITLE
Upgrade scallop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
-            <version>1.0.1</version>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/Conf.scala
@@ -59,11 +59,15 @@ class Conf(args: Seq[String], props: PropertiesConfiguration) extends ScallopCon
     default = None)
   val bagDirectory = trailArg[File](name = "bag-directory", required = true,
     descr = "Directory in BagIt format that will be sent to archival storage")
+
+  validateFileExists(bagDirectory)
+  
   validateOpt(bagDirectory) {
     case Some(dir) =>
       Right(Unit)
     case _ => Left("Could not parse parameter <bag-directory>")
   }
+
   val storageServiceUrl = trailArg[URL](
     name = "storage-service-url",
     required = false,

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/Conf.scala
@@ -21,6 +21,10 @@ import java.io.File
 import java.net.URL
 
 class Conf(args: Seq[String], props: PropertiesConfiguration) extends ScallopConf(args) {
+
+  appendDefaultToDescription = true
+  editBuilder(_.setHelpWidth(110))
+
   printedName = "easy-archive-bag"
   version(s"$printedName ${Version()}")
   banner("""
@@ -67,4 +71,6 @@ class Conf(args: Seq[String], props: PropertiesConfiguration) extends ScallopCon
       case s: String => Some(new URL(s))
       case _ => throw new RuntimeException("No storage service URL provided")
     })
+
+  verify()
 }


### PR DESCRIPTION
fixes EASY- Upgrade scallop

#### When applied it will
* use the version 1.0.1 of scallop

#### Where should the reviewer @DANS-KNAW/easy start?
Conf   pom.xml

#### How should this be manually tested?
* execute ./run.sh --help (provide first the app.home, see https://github.com/DANS-KNAW/easy-dtap#running-a-new-component)

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 

