### PR TITLE
Use Zip4J instead of own directory zipping function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>scalatest_2.11</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
             <exclusions>


### PR DESCRIPTION
No JIRA issue.

Refactored the part that zips the deposited bag for transer to the bag store. It was implemented with a home grown directory zipping function, replaced that with Zip4J.