### PR TITLE
1248 enhanced error reporting

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
@@ -115,7 +115,7 @@ object EasyArchiveBag extends Bagit4FacadeComponent with DebugEnhancedLogging {
     FileUtils.write(bagDir.resolve("refbags.txt").toFile, refBagsTxt, "UTF-8")
   }
 
-  @throws
+  @throws[IOException]("when creating the temp file name failed")
   private def generateUncreatedTempFile()(implicit ps: Parameters): File =  try {
     val tempFile = File.createTempFile("easy-archive-bag-", ".zip", ps.tempDir)
     tempFile.delete()

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
@@ -17,21 +17,22 @@ package nl.knaw.dans.easy.archivebag
 
 import java.io._
 import java.net.URI
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{ Files, Path, Paths }
 import java.util.UUID
-import java.util.zip.{ZipEntry, ZipOutputStream}
+import java.util.zip.{ ZipEntry, ZipOutputStream }
 
 import net.lingala.zip4j.core.ZipFile
 import net.lingala.zip4j.model.ZipParameters
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.codec.digest.DigestUtils
-import org.apache.commons.io.{FileUtils, IOUtils}
-import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
-import org.apache.http.client.methods.{CloseableHttpResponse, HttpGet, HttpPut}
-import org.apache.http.entity.{ContentType, FileEntity}
-import org.apache.http.impl.client.{BasicCredentialsProvider, CloseableHttpClient, HttpClients}
+import org.apache.commons.io.{ FileUtils, IOUtils }
+import org.apache.http.auth.{ AuthScope, UsernamePasswordCredentials }
+import org.apache.http.client.methods.{ CloseableHttpResponse, HttpGet, HttpPut }
+import org.apache.http.entity.{ ContentType, FileEntity }
+import org.apache.http.impl.client.{ BasicCredentialsProvider, CloseableHttpClient, HttpClients }
 
-import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+import scala.util.{ Failure, Success, Try }
 
 object EasyArchiveBag extends Bagit4FacadeComponent with DebugEnhancedLogging {
   import logger._
@@ -115,11 +116,13 @@ object EasyArchiveBag extends Bagit4FacadeComponent with DebugEnhancedLogging {
     FileUtils.write(bagDir.resolve("refbags.txt").toFile, refBagsTxt, "UTF-8")
   }
 
-  private def generateUncreatedTempFile()(implicit ps: Parameters): File =  {
+  private def generateUncreatedTempFile()(implicit ps: Parameters): File =  try {
     val tempFile = File.createTempFile("easy-archive-bag-", ".zip", ps.tempDir)
     tempFile.delete()
     debug(s"Generated unique temporary file name: $tempFile")
     tempFile
+  } catch {
+    case e: Exception => throw new IOException(s"Could not create temp file in ${ps.tempDir}: ${e.getMessage}", e)
   }
 
   private def zipDir(dir: File, zip: File) = {

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
@@ -19,7 +19,6 @@ import java.io._
 import java.net.URI
 import java.nio.file.{ Files, Path, Paths }
 import java.util.UUID
-import java.util.zip.{ ZipEntry, ZipOutputStream }
 
 import net.lingala.zip4j.core.ZipFile
 import net.lingala.zip4j.model.ZipParameters
@@ -116,13 +115,14 @@ object EasyArchiveBag extends Bagit4FacadeComponent with DebugEnhancedLogging {
     FileUtils.write(bagDir.resolve("refbags.txt").toFile, refBagsTxt, "UTF-8")
   }
 
+  @throws
   private def generateUncreatedTempFile()(implicit ps: Parameters): File =  try {
     val tempFile = File.createTempFile("easy-archive-bag-", ".zip", ps.tempDir)
     tempFile.delete()
     debug(s"Generated unique temporary file name: $tempFile")
     tempFile
   } catch {
-    case e: Exception => throw new IOException(s"Could not create temp file in ${ps.tempDir}: ${e.getMessage}", e)
+    case NonFatal(e) => throw new IOException(s"Could not create temp file in ${ps.tempDir}: ${e.getMessage}", e)
   }
 
   private def zipDir(dir: File, zip: File) = {


### PR DESCRIPTION
fixes EASY-1248

#### When applied it will
* tell which temp file it could not create
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Build this and https://github.com/DANS-KNAW/easy-ingest-flow/pull/19, deploy and run the latter on a fresh deasy from the command line. It will report `FAILED: Could not create temp file in /data/tmp/easy-archive-bag-tmp: Permission denied`. That used to be `FAILED: Permission denied`.

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
