### PR TITLE
EASY-1013 - upgrade to BagIt 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>5.0.1</version>
+            <version>5.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>xml-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@
     <parent>
        <groupId>nl.knaw.dans.shared</groupId>
        <artifactId>dans-scala-prototype</artifactId>
-       <version>1.35</version>
+       <version>1.47</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-archive-bag</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
+            <version>5.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>xml-apis</groupId>

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -35,7 +35,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/src/main/assembly/dist/bin</directory>
-            <outputDirectory>/bin</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -7,7 +7,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}</directory>
-            <outputDirectory>/bin</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
@@ -40,9 +40,9 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/src/main/assembly/dist</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <excludes>
-                <exclude>/bin/*</exclude>
+                <exclude>bin/*</exclude>
             </excludes>
         </fileSet>
     </fileSets>

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/BagitFacadeComponent.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/BagitFacadeComponent.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/BagitFacadeComponent.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/BagitFacadeComponent.scala
@@ -38,10 +38,10 @@ trait BagFacadeComponent {
   }
 }
 
-trait Bagit4FacadeComponent extends BagFacadeComponent {
+trait Bagit5FacadeComponent extends BagFacadeComponent {
   this: DebugEnhancedLogging =>
 
-  class Bagit4Facade(bagReader: BagReader = new BagReader) extends BagFacade {
+  class Bagit5Facade(bagReader: BagReader = new BagReader) extends BagFacade {
 
     private def entryToTuple[K, V](entry: Entry[K, V]): (K, V) = entry.getKey -> entry.getValue
 

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/CommandLineOptions.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,19 +16,17 @@
 package nl.knaw.dans.easy.archivebag
 
 import java.io.File
-import java.net.{URI, URL}
+import java.net.{ URI, URL }
 import java.util.UUID
 
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.rogach.scallop.{ScallopConf, ScallopOption}
-import org.slf4j.LoggerFactory
+import org.rogach.scallop.{ ScallopConf, ScallopOption }
 
-object CommandLineOptions {
-
-  val log = LoggerFactory.getLogger(getClass)
+object CommandLineOptions extends DebugEnhancedLogging {
 
   def parse(args: Array[String]): Parameters = {
-    log.debug("Loading application.properties ...")
+    debug("Loading application.properties ...")
 
     val homeDir = new File(System.getProperty("app.home"))
     val props = {
@@ -37,7 +35,7 @@ object CommandLineOptions {
       ps.load(new File(homeDir, "cfg/application.properties"))
       ps
     }
-    log.debug("Parsing command line ...")
+    debug("Parsing command line ...")
     val conf = new ScallopCommandLine(props, args)
     conf.verify()
 
@@ -50,7 +48,7 @@ object CommandLineOptions {
       bagIndexService = new URI(props.getString("bag-index.uri")),
       uuid = UUID.fromString(conf.uuid()))
 
-    log.debug(s"Using the following settings: $settings")
+    debug(s"Using the following settings: $settings")
 
     settings
   }

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBag.scala
@@ -34,10 +34,10 @@ import org.apache.http.impl.client.{ BasicCredentialsProvider, CloseableHttpClie
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-object EasyArchiveBag extends Bagit4FacadeComponent with DebugEnhancedLogging {
+object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
   import logger._
   type BagId = UUID
-  val bagFacade = new Bagit4Facade()
+  val bagFacade = new Bagit5Facade()
 
   def main(args: Array[String]) {
     implicit val settings = CommandLineOptions.parse(args)

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/package.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/archivebag/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/archivebag/package.scala
@@ -21,7 +21,8 @@ import java.nio.file.Path
 import java.util.UUID
 
 package object archivebag {
-  case class BagNotFoundException(bagDir: Path, cause: Throwable) extends Exception(s"A bag could not be loaded at $bagDir", cause)
+  case class NotABagDirException(bagDir: Path, cause: Throwable) extends Exception(s"A bag could not be loaded at $bagDir", cause)
+  case class BagReaderException(bagDir: Path, cause: Throwable) extends Exception(s"The bag at '$bagDir' could not be read: ${ cause.getMessage }", cause)
   case class InvalidIsVersionOfException(value: String) extends Exception(s"Unsupported value in the bag-info.txt field Is-Version-Of: $value")
 
   val IS_VERSION_OF_KEY = "Is-Version-Of"


### PR DESCRIPTION
fixes EASY-1013

#### When applied it will
* upgrade to BagIt 5.x
* upgrade parent to 1.47 (+ `bin.xml` and licenses)

@DANS-KNAW/easy for review