### PR TITLE
PR33 comments

### DIFF
--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -14,8 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -e # abort when a command fails
 
 DATADIR=data
+
+if [ -e ${DATADIR} ]; then
+    mv ${DATADIR} ${DATADIR}-`date  +"%Y-%m-%d@%H:%M:%S"`
+fi
+mkdir ${DATADIR}
 
 touch ${DATADIR}/easy-archive-bag.log
 

--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -18,10 +18,9 @@
 set -e # abort when a command fails
 
 DATADIR=data
-DATEVAL=$(date  +"%Y-%m-%d@%H:%M:%S")
 
 if [ -e ${DATADIR} ]; then
-    mv ${DATADIR} ${DATADIR}-${DATEVAL}
+    mv ${DATADIR} ${DATADIR}-$(date  +"%Y-%m-%d@%H:%M:%S")
 fi
 mkdir ${DATADIR}
 

--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -18,9 +18,10 @@
 set -e # abort when a command fails
 
 DATADIR=data
+DATEVAL=$(date  +"%Y-%m-%d@%H:%M:%S")
 
 if [ -e ${DATADIR} ]; then
-    mv ${DATADIR} ${DATADIR}-`date  +"%Y-%m-%d@%H:%M:%S"`
+    mv ${DATADIR} ${DATADIR}-${DATEVAL}
 fi
 mkdir ${DATADIR}
 

--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 set -e # abort when a command fails
 
 DATADIR=data

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
@@ -74,7 +74,7 @@ trait Bagit5FacadeComponent extends BagFacadeComponent {
       case NonFatal(cause) => Failure(NotABagDirException(bagDir, cause))
     }
 
-    // TODO: canditate for easy-bagit-lib
+    // TODO: candidate for easy-bagit-lib
     private def getIsVersionOfFromUri(uri: URI): Try[UUID] = {
       if (uri.getScheme == "urn") {
         val uuidPart = uri.getSchemeSpecificPart

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/Configuration.scala
@@ -28,13 +28,17 @@ object Configuration {
 
   def apply(): Configuration = {
     val home = Paths.get(System.getProperty("app.home"))
-    val cfgPath = Seq(Paths.get(s"/etc/opt/dans.knaw.nl/easy-archive-bag/"), home.resolve("cfg"))
+    val defaultPath = Paths.get(s"/etc/opt/dans.knaw.nl/easy-archive-bag/")
+    val configuredPath = home.resolve("cfg")
+    val cfgPath = Seq(defaultPath, configuredPath)
       .find(Files.exists(_))
       .getOrElse { throw new IllegalStateException("No configuration directory found") }
 
+    val versionFile = home.resolve("bin/version").toFile
+    val configFile = cfgPath.resolve("application.properties").toFile
     new Configuration(
-      version = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString),
-      properties = new PropertiesConfiguration(cfgPath.resolve("application.properties").toFile)
+      version = managed(Source.fromFile(versionFile)).acquireAndGet(_.mkString),
+      properties = new PropertiesConfiguration(configFile)
     )
   }
 }

--- a/src/test/resources/bags/basic-sequence-unpruned/README.txt
+++ b/src/test/resources/bags/basic-sequence-unpruned/README.txt
@@ -1,5 +1,5 @@
-This is a sequence of three bags. First a is added, then b and then c.
-b is modified version of a, and c is modified further. Below the payload
+This is a sequence of three bags. First A is added, then B and then C.
+B is modified version of A, and C is modified further. Below the payload
 of each bag is listed, and for each file in b and c how it relates to the
 previous bags and how it is expected to be represented. The contents of
 all the file is different, unless it is specifically said to be the same
@@ -8,7 +8,7 @@ as another file.
 These things should all be checked in the unit tests, so this description
 is slightly redundant. However, it may be useful as an overview.
 
-a:
+A:
 data/sub/u
 data/sub/v
 data/sub/w
@@ -17,7 +17,7 @@ data/x
 data/y
 data/z
 
-b:
+B:
 data/sub/u      unchanged               => reference in fetch.txt
 [data/sub/v]    moved                   => not present here, no reference in fetch.txt
 [data/sub/w]    deleted                 => not present here, no reference in fetch.txt
@@ -28,7 +28,7 @@ data/y          changed                 => actual file
 data/y-old      copy of y               => reference in fetch.txt
 [data/z]        deleted                 => not present, no reference in fetch.txt
 
-c:
+C:
 data/sub/q      new file                => actual file
 data/sub/w      restored file from a    => actual file if only b is ref-bag, reference in fetch.txt if a is also ref-bag
 


### PR DESCRIPTION
fixes https://github.com/DANS-KNAW/easy-archive-bag/pull/33#discussion_r130375393

Just not sure about dropping `From` from `getIsVersionOfFromUri`, so didn't do it.

#### When applied it will
* easier to read
* abort shell script on error
* make a backup of the old `data` directory

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Run `./debug-init-env.sh` once or twice: it renames the old version appending a date.

Make the `data` folder inaccessible or cause some other error and run the same script: the last echoed line should be an error message, not `OK`


#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
