### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
-system "ansible-galaxy install --force --role-file=#{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml"
+system "ansible-galaxy install --force --role-file=#{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml" if (ARGV[0] == "up" || ARGV[0] == "provision")
 Vagrant.configure(2) do |config|
    config.vm.define "test" do |test|
       test.vm.box = "geerlingguy/centos6"
@@ -8,6 +8,7 @@ Vagrant.configure(2) do |config|
       test.vm.provision "ansible" do |ansible|
         ansible.playbook = "src/main/ansible/vagrant.yml"
         ansible.config_file = "src/main/ansible/ansible.cfg"
+        ansible.compatibility_mode = "2.0"
 #        ansible.verbose = "vvvv"
       end
       test.vm.provider "virtualbox" do |vb|

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
        <groupId>nl.knaw.dans.shared</groupId>
        <artifactId>dans-scala-prototype</artifactId>
-       <version>1.62</version>
+       <version>1.63-SNAPSHOT</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-archive-bag</artifactId>
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
@@ -50,11 +50,11 @@
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
+            <artifactId>scala-xml_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
@@ -80,17 +80,10 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>5.0.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
        <groupId>nl.knaw.dans.shared</groupId>
        <artifactId>dans-scala-prototype</artifactId>
-       <version>1.63-SNAPSHOT</version>
+       <version>1.64</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-archive-bag</artifactId>

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.archivebag
 
 import java.io.File
 import java.net.{ URI, URL }
+import java.nio.file.Paths
 import java.util.UUID
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -27,7 +28,7 @@ object CommandLineOptions extends DebugEnhancedLogging {
   def parse(args: Array[String]): Parameters = {
     debug("Loading application.properties ...")
 
-    val configuration = Configuration()
+    val configuration = Configuration(Paths.get(System.getProperty("app.home")))
     debug("Parsing command line ...")
     val cmd = new ScallopCommandLine(configuration, args)
     cmd.verify()

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/Configuration.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.archivebag
 
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.commons.configuration.PropertiesConfiguration
 import resource.managed
@@ -26,8 +26,7 @@ case class Configuration(version: String, properties: PropertiesConfiguration)
 
 object Configuration {
 
-  def apply(): Configuration = {
-    val home = Paths.get(System.getProperty("app.home"))
+  def apply(home: Path): Configuration = {
     val cfgPath = Seq(Paths.get(s"/etc/opt/dans.knaw.nl/easy-archive-bag/"), home.resolve("cfg"))
       .find(Files.exists(_))
       .getOrElse { throw new IllegalStateException("No configuration directory found") }

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -22,6 +22,7 @@ import java.nio.file.{ Files, Path, Paths }
 
 import net.lingala.zip4j.core.ZipFile
 import net.lingala.zip4j.model.ZipParameters
+import nl.knaw.dans.lib.error.TryExtensions
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.{ FileUtils, IOUtils }
@@ -40,7 +41,7 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
 
   def main(args: Array[String]) {
     implicit val settings: Parameters = CommandLineOptions.parse(args)
-    run.get
+    run.unsafeGetOrThrow
   }
 
   def run(implicit ps: Parameters): Try[URI] = Try {


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* provide a parameter to the `Configuration` constructor
* use the `dans-scala-lib` functions
* add `compatibility_mode` and extra if-clause to `Vagrantfile`

@DANS-KNAW/easy for review