### PR TITLE
EASY-1535: Guard easy-bag-store with username/password

### DIFF
--- a/src/main/ansible/conditions.fact
+++ b/src/main/ansible/conditions.fact
@@ -6,6 +6,5 @@ def can_connect_to_postgresql_db(db):
     return os.system('sudo -u postgres psql -U postgres -c "\q" ' + db) == 0
 
 print json.dumps({
-    'database_not_installed': not can_connect_to_postgresql_db('easy_bag_index'),
-    'test_data_does_not_exist': not os.path.exists('/home/vagrant/test-data/')
+    'database_not_installed': not can_connect_to_postgresql_db('easy_bag_index')
 })

--- a/src/main/ansible/vagrant.yml
+++ b/src/main/ansible/vagrant.yml
@@ -43,13 +43,11 @@
     setup: filter=ansible_local
     when: result.changed
 
-  - name: Copy test-data to vagrant home
-    copy:
-      src: ../../test/resources/bags/basic-sequence-unpruned/
-      dest: /home/vagrant/test-data/
-      mode: "0777"
-      directory_mode: "0777"
-    when: ansible_local.conditions.test_data_does_not_exist
+  - name: Create link to test data
+    file:
+      src: /vagrant/src/test/resources/bags
+      dest: /home/vagrant/test-data
+      state: link
 
   - name: Install packages
     yum:

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,5 +1,2 @@
-default.storage-service-url=
-default.storage-service-username=
-default.storage-service-password=
 tempdir=/var/opt/dans.knaw.nl/tmp/easy-archive-bag-staging
 bag-index.uri=http://localhost:20120/

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
@@ -63,35 +63,34 @@ class ScallopCommandLine(configuration: Configuration, args: Array[String]) exte
        |Options:
        |""".stripMargin)
 
-  val username: ScallopOption[String] = opt[String]("username",
+  val username: ScallopOption[String] = opt[String](
+    name = "username",
+    short = 'u',
     descr = "Username to use for authentication/authorisation to the storage service",
-    default = configuration.properties.getString("default.storage-service-username") match {
-      case s: String => Some(s)
-      case _ => throw new RuntimeException("No username provided")
-    })
+    required = true,
+  )
 
-  val password: ScallopOption[String] = opt[String]("password",
+  val password: ScallopOption[String] = opt[String](
+    name = "password",
+    short = 'p',
     descr = "Password to use for authentication/authorisation to the storage service",
-    default = configuration.properties.getString("default.storage-service-password") match {
-      case s: String => Some(s)
-      case _ => throw new RuntimeException("No password provided")
-    })
+    required = true,
+  )
 
-  val bagDirectory: ScallopOption[File] = trailArg[File](name = "bag-directory", required = true,
-    descr = "Directory in BagIt format that will be sent to archival storage")
+  val bagDirectory: ScallopOption[File] = trailArg[File](
+    name = "bag-directory",
+    descr = "Directory in BagIt format that will be sent to archival storage",
+  )
 
   val uuid: ScallopOption[String] = trailArg[String](
     name = "uuid",
     descr = "Identifier for the bag in archival storage",
-    required = true)
+  )
 
   val storageServiceUrl: ScallopOption[URL] = trailArg[URL](
     name = "storage-service-url",
-    required = false,
-    default = configuration.properties.getString("default.storage-service-url") match {
-      case s: String => Some(new URL(s))
-      case _ => throw new RuntimeException("No storage service URL provided")
-    })
+    descr = "base url to the store in which the bag needs to be archived",
+  )
 
   validateFileExists(bagDirectory)
   validateOpt(bagDirectory) {

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -64,6 +64,8 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
         }
         zippedBag.delete()
         location
+      case HttpStatus.SC_UNAUTHORIZED =>
+        throw UnautherizedException(ps.bagId)
       case _ =>
         throw new RuntimeException(s"Bag archiving failed: ${ response.getStatusLine }")
     }

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
@@ -24,6 +24,7 @@ package object archivebag {
   case class NotABagDirException(bagDir: Path, cause: Throwable) extends Exception(s"A bag could not be loaded at $bagDir", cause)
   case class BagReaderException(bagDir: Path, cause: Throwable) extends Exception(s"The bag at '$bagDir' could not be read: ${ cause.getMessage }", cause)
   case class InvalidIsVersionOfException(value: String) extends Exception(s"Unsupported value in the bag-info.txt field Is-Version-Of: $value")
+  case class UnautherizedException(bagId: BagId) extends Exception(s"No or invalid credentials provided for storage deposit service while depositing bag $bagId")
 
   type BagId = UUID
 

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,5 +1,2 @@
-default.storage-service-url=http://test.dans.knaw.nl:20110/stores/default/
-default.storage-service-username=
-default.storage-service-password=
 tempdir=data/easy-archive-bag-staging/
 bag-index.uri=http://test.dans.knaw.nl:20120/


### PR DESCRIPTION
fixes EASY-1535

#### When applied it will
* remove unused defaults
* finally make use of the username/password parameters
* fix the commandline options
* provide a proper exception when no/invalid credentials for `easy-bag-store` are provided
* in test VM use a link to the testdata folder rather than copying it

@DANS-KNAW/easy for review

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-bag-store                      | [PR#60](https://github.com/DANS-KNAW/easy-bag-store/pull/60) 
easy-ingest-flow | [PR#72](https://github.com/DANS-KNAW/easy-ingest-flow/pull/72)
easy-dtap | [PR#212](https://github.com/DANS-KNAW/easy-dtap/pull/212)