### PR TITLE
EASY-1636 UnsupportedOperationException: empty.reduceLeft

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -68,7 +68,7 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
       case HttpStatus.SC_UNAUTHORIZED =>
         throw UnautherizedException(ps.bagId)
       case _ =>
-        throw new RuntimeException(s"Bag archiving failed: ${ response.getStatusLine }")
+        throw new RuntimeException(s"Bag archiving failed: ${ps.storageDepositService.toString} returned: ${ response.getStatusLine }. ZippedBag=$zippedBag")
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -68,7 +68,8 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
       case HttpStatus.SC_UNAUTHORIZED =>
         throw UnautherizedException(ps.bagId)
       case _ =>
-        throw new RuntimeException(s"Bag archiving failed: ${ ps.storageDepositService } returned:[ ${ response.getStatusLine } ]. ZippedBag=$zippedBag")
+        logger.error(s"${ ps.storageDepositService } returned:[ ${ response.getStatusLine } ]. ZippedBag=$zippedBag")
+        throw new RuntimeException(s"Bag archiving failed: ${ response.getStatusLine }")
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -90,16 +90,17 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
     val response = http.execute(get)
     val statusLine = response.getStatusLine
     if (statusLine.getStatusCode != HttpStatus.SC_OK)
-      throwBagNotFoud(bagId, s"bag index [${get.getURI}] returned ${statusLine.getStatusCode} ${statusLine.getReasonPhrase}")
+      throwBagNotFoud(bagId, s"[${get.getURI}] returned ${statusLine.getStatusCode} ${statusLine.getReasonPhrase}")
     IOUtils.copy(response.getEntity.getContent, sw, "UTF-8")
     sw.toString match {
-      case s if s.isBlank => throwBagNotFoud(bagId, s"is not found in bag index [${get.getURI}]")
+      case s if s.isBlank => throwBagNotFoud(bagId, s"Empty response body from [${get.getURI}]")
       case s => Some(s)
     }
   }
 
   private def throwBagNotFoud (bagId: BagId, reason: String) = {
-    throw new IllegalStateException(s"Bag with bag-id $bagId, pointed to by Is-Version-Of field in bag-info.txt, $reason")
+    logger.error(reason)
+    throw new IllegalStateException(s"Bag with bag-id $bagId, pointed to by Is-Version-Of field in bag-info.txt is not found in bag index.")
   }
 
   private def writeRefBagsTxt(bagDir: Path)(refBagsTxt: String): Try[Unit] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -68,7 +68,7 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
       case HttpStatus.SC_UNAUTHORIZED =>
         throw UnautherizedException(ps.bagId)
       case _ =>
-        throw new RuntimeException(s"Bag archiving failed: ${ps.storageDepositService.toString} returned: ${ response.getStatusLine }. ZippedBag=$zippedBag")
+        throw new RuntimeException(s"Bag archiving failed: ${ps.storageDepositService.toString} returned:[ ${ response.getStatusLine } ]. ZippedBag=$zippedBag")
     }
   }
 


### PR DESCRIPTION
fixes EASY-1636 UnsupportedOperationException: empty.reduceLeft

#### When applied it will
* throw an exception when the bag-index doesn't find a referenced bag. 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

on a fresh deasy (with no bags in the store)

    easy-archive-bag -u user001 -p user001 deposit-1636/doi_10.5061_dryad.8157n/ f6b26ef9-8270-4092-b852-25d339d2bc6b http://localhost:20110

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
