### PR TITLE
EASY-1670 Command-line startup script: argumenten met spaties

### DIFF
--- a/src/main/assembly/dist/bin/easy-archive-bag
+++ b/src/main/assembly/dist/bin/easy-archive-bag
@@ -16,4 +16,4 @@ fi
 
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
-     -jar $APPHOME/bin/easy-archive-bag.jar $@
+     -jar $APPHOME/bin/easy-archive-bag.jar "$@"


### PR DESCRIPTION
fixes EASY-1670

#### When applied
* Fixes EASY-1670 Command-line startup script: argumenten met spaties

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
