### PR TITLE
EASY-1697: Let bag-store-url work without trailing slash

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
@@ -51,7 +51,7 @@ class ScallopCommandLine(configuration: Configuration, args: Array[String]) exte
   with DefaultConverters {
 
   private implicit val urlConverter: ValueConverter[URL] = singleArgConverter(s => new URL(addTrailingSlashIfNeeded(s)), {
-    case e: MalformedURLException => Left("bad URL, %s" format e.getMessage)
+    case e: MalformedURLException => Left(s"bad URL, ${ e.getMessage }")
   })
 
   private def addTrailingSlashIfNeeded(s: String): String = {

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
@@ -21,7 +21,7 @@ import java.nio.file.Paths
 import java.util.UUID
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.rogach.scallop.{ DefaultConverters, ScallopConf, ScallopOption, ValueConverter }
+import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter, singleArgConverter }
 
 object CommandLineOptions extends DebugEnhancedLogging {
   def parse(args: Array[String]): Parameters = {
@@ -47,8 +47,7 @@ object CommandLineOptions extends DebugEnhancedLogging {
   }
 }
 
-class ScallopCommandLine(configuration: Configuration, args: Array[String]) extends ScallopConf(args)
-  with DefaultConverters {
+class ScallopCommandLine(configuration: Configuration, args: Array[String]) extends ScallopConf(args) {
 
   private implicit val urlConverter: ValueConverter[URL] = singleArgConverter(s => new URL(addTrailingSlashIfNeeded(s)), {
     case e: MalformedURLException => Left(s"bad URL, ${ e.getMessage }")

--- a/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.archivebag/CommandLineOptions.scala
@@ -90,7 +90,7 @@ class ScallopCommandLine(configuration: Configuration, args: Array[String]) exte
   val bagStoreUrl: ScallopOption[URL] = trailArg[URL](
     name = "bag-store-url",
     descr = "base url to the store in which the bag needs to be archived",
-  )
+  ).map(url => if (url.toString.endsWith("/")) url else new URL(url.toString.concat("/")))
 
   validateFileExists(bagDirectory)
   validateOpt(bagDirectory) {


### PR DESCRIPTION
- [x] find a cleaner solution

fixes EASY-1697, bag-store-url now also works without providing trailing slash


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

steps
1. deploy role to easy
2. ssh to ready (vagrant ssh)
3.  type:`easy-archive-bag -u easy-bag-store -p replace_me  path/to/local/bag ca30bf26-e27b-4a96-8df6-a10bf3c63e2b http://localhost:20110/stores/easy/`
4. type: `easy-archive-bag -u easy-bag-store -p easy_bag_store path/to/local/bag ca30bf26-e27b-4a96-8df6-a10bf3c63e2b http://localhost:20110/stores/easy`
