### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
@@ -25,6 +25,7 @@ import gov.loc.repository.bagit.domain.Bag
 import gov.loc.repository.bagit.exceptions._
 import gov.loc.repository.bagit.reader.BagReader
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
@@ -80,7 +81,7 @@ trait Bagit5FacadeComponent extends BagFacadeComponent {
         val uuidPart = uri.getSchemeSpecificPart
         val parts = uuidPart.split(':')
         if (parts.length != 2) Failure(InvalidIsVersionOfException(uri.toASCIIString))
-        else Try { UUID.fromString(parts(1)) }
+        else parts(1).toUUID.toTry
       }
       else Failure(InvalidIsVersionOfException(uri.toASCIIString))
     }


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..
