### PR TITLE
EASY-2474 Convert documentation to mkdocs

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GH_ORG=DANS-KNAW
+
+set -e
+
+# Relies on Travis checking out repo to a dir with the repo's name.
+GH_REPO=$(basename $TRAVIS_BUILD_DIR)
+REMOTE="https://${GH_TOKEN}@github.com/${GH_ORG}/${GH_REPO}"
+git remote set-url origin ${REMOTE}
+
+echo "START installing required Python packages..."
+pip3 install mkdocs
+pip3 install pygments
+pip3 install pymdown-extensions
+pip3 install pyyaml
+pip3 install mkdocs-markdownextradata-plugin
+echo "DONE installing required Python packages."
+
+echo "START installing DANS mkdocs theme..."
+git clone https://github.com/Dans-labs/mkdocs-dans $HOME/mkdocs-dans
+pushd $HOME/mkdocs-dans
+git pull
+python3 build.py pack
+popd
+echo "DONE installing DANS mkdocs theme."
+
+echo "START deploying docs to GitHub pages..."
+mkdocs gh-deploy --force
+echo "DONE deploying docs to GitHub pages."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
-language: java
-jdk: openjdk8
-cache:
-  directories:
-    - "$HOME/.m2/repository"
+matrix:
+  include:
+    - language: java
+      jdk: openjdk8
+      cache:
+        directories:
+          - "$HOME/.m2/repository"
+    - language: python
+      if: branch = master AND NOT type = pull_request
+      python: 3.7.1
+      cache:
+        directories:
+          - "$HOME/.cache"
+          - "$HOME/virtualenv"
+      script:
+        - "./.travis.sh"

--- a/README.md
+++ b/README.md
@@ -4,66 +4,7 @@ easy-archive-bag
 
 Send a bag to archival storage.
 
+Welcome
+-------
 
-SYNOPSIS
---------
-
-    easy-archive-bag [--user|-u <user>][--password,-p <password] \
-                       <bag-directory> <uuid> [<bag-store-service-url>]
-
-
-DESCRIPTION
------------
-
-Takes a directory in BagIt format, zips it and sends it via an HTTP `PUT` request to 
-`bag-store-url/<uuid>`. If the `bag-info.txt` contains an entry `Is-Version-Of` the
-value must be a valid bag-id. Note that the `bag-store-url` only contains the base
-URL of the bag store, e.g. `http://myarchive/bagstores/mybagstore`.
-
-
-ARGUMENTS
----------
-
-    Options:
-
-      -p, --password  <arg>   Password to use for authentication/authorisation to the storage service
-      -u, --username  <arg>   Username to use for authentication/authorisation to the storage service
-      -h, --help              Show help message
-      -v, --version           Show version of this program
-
-     trailing arguments:
-      bag-directory (required)         Directory in BagIt format that will be sent to archival storage
-      uuid (required)                  Identifier for the bag in archival storage
-      bag-store-url (required)         base url to the store in which the bag needs to be archived
-
-INSTALLATION AND CONFIGURATION
-------------------------------
-The preferred way of install this module is using the RPM package. This will install the binaries to
-`/opt/dans.knaw.nl/easy-archive-bag` and the configuration files to `/etc/opt/dans.knaw.nl/easy-archive-bag`.
-
-To install the module on systems that do not support RPM, you can copy and unarchive the tarball to the target host.
-You will have to take care of placing the files in the correct locations for your system yourself. For instructions
-on building the tarball, see next section.
-
-BUILDING FROM SOURCE
---------------------
-
-Prerequisites:
-
-* Java 8 or higher
-* Maven 3.3.3 or higher
-* RPM
-
-Steps:
-
-    git clone https://github.com/DANS-KNAW/easy-archive-bag.git
-    cd easy-archive-bag
-    mvn install
-
-If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM
-packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
-Maven's `-P` switch: `mvn -Pprm install`.
-
-Alternatively, to build the tarball execute:
-
-    mvn clean install assembly:single
+Welcome to the `easy-archive-bag` project. See the [GitHub pages](https://dans-knaw.github.io/easy-archive-bag/) for the manual.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,69 @@
+MANUAL
+======
+[![Build Status](https://travis-ci.org/DANS-KNAW/easy-archive-bag.svg?branch=master)](https://travis-ci.org/DANS-KNAW/easy-archive-bag)
+
+Send a bag to archival storage.
+
+
+SYNOPSIS
+--------
+
+    easy-archive-bag [--user|-u <user>][--password,-p <password] \
+                       <bag-directory> <uuid> [<bag-store-service-url>]
+
+
+DESCRIPTION
+-----------
+
+Takes a directory in BagIt format, zips it and sends it via an HTTP `PUT` request to 
+`bag-store-url/<uuid>`. If the `bag-info.txt` contains an entry `Is-Version-Of` the
+value must be a valid bag-id. Note that the `bag-store-url` only contains the base
+URL of the bag store, e.g. `http://myarchive/bagstores/mybagstore`.
+
+
+ARGUMENTS
+---------
+
+    Options:
+
+      -p, --password  <arg>   Password to use for authentication/authorisation to the storage service
+      -u, --username  <arg>   Username to use for authentication/authorisation to the storage service
+      -h, --help              Show help message
+      -v, --version           Show version of this program
+
+     trailing arguments:
+      bag-directory (required)         Directory in BagIt format that will be sent to archival storage
+      uuid (required)                  Identifier for the bag in archival storage
+      bag-store-url (required)         base url to the store in which the bag needs to be archived
+
+INSTALLATION AND CONFIGURATION
+------------------------------
+The preferred way of install this module is using the RPM package. This will install the binaries to
+`/opt/dans.knaw.nl/easy-archive-bag` and the configuration files to `/etc/opt/dans.knaw.nl/easy-archive-bag`.
+
+To install the module on systems that do not support RPM, you can copy and unarchive the tarball to the target host.
+You will have to take care of placing the files in the correct locations for your system yourself. For instructions
+on building the tarball, see next section.
+
+BUILDING FROM SOURCE
+--------------------
+
+Prerequisites:
+
+* Java 8 or higher
+* Maven 3.3.3 or higher
+* RPM
+
+Steps:
+
+    git clone https://github.com/DANS-KNAW/easy-archive-bag.git
+    cd easy-archive-bag
+    mvn install
+
+If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM
+packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
+Maven's `-P` switch: `mvn -Pprm install`.
+
+Alternatively, to build the tarball execute:
+
+    mvn clean install assembly:single

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+site_name: easy-archive-bag
+theme:
+  name: dans
+  disclaimer: false
+
+repo_name: DANS-KNAW/easy-archive-bag
+repo_url: https://github.com/DANS-KNAW/easy-archive-bag
+
+nav:
+  - Manual: index.md
+
+plugins:
+  - markdownextradata
+  - search
+
+markdown_extensions:
+  - attr_list
+  #- legacy_attr
+  - admonition
+  - codehilite:
+      guess_lang: false
+  - def_list
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.critic
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: Dans-labs
+      repo: mkdocs-dans
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde


### PR DESCRIPTION
fixes EASY-2474

#### When applied it will
* convert the project documentation to mkdocs format

#### Where should the reviewer @DANS-KNAW/easy start?
check out the project, run `mkdocs serve`

#### How should this be manually tested?
https://dans-labs.github.io/mkdocs-dans/