### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/command/pom.xml
+++ b/command/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath />
     </parent>
     

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath />
     </parent>
     

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.1</version>
         </dependency>
     </dependencies>
     

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath />
     </parent>
     

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath />
     </parent>
     

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -20,7 +20,7 @@ import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
-import net.lingala.zip4j.core.ZipFile
+import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.model.ZipParameters
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -129,9 +129,7 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
   private def zipDir(dir: File, zip: File)(implicit bagId: BagId): Try[Unit] = Try {
     logger.info(s"[$bagId] Zipping directory $dir to file $zip")
     if (zip.exists) zip.delete
-    val zf = new ZipFile(zip) {
-      setFileNameCharset(StandardCharsets.UTF_8.name)
-    }
+    val zf = new ZipFile(zip)
     val parameters = new ZipParameters
     zf.addFolder(dir, parameters)
   }

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -48,7 +47,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
