### PR TITLE
EASY-2050: Roep AIP validatie aan in easy-archive-bag

### DIFF
--- a/command/src/main/assembly/dist/cfg/application.properties
+++ b/command/src/main/assembly/dist/cfg/application.properties
@@ -16,3 +16,7 @@
 
 tempdir=/var/opt/dans.knaw.nl/tmp/easy-archive-bag-staging
 bag-index.uri=http://localhost:20120/
+
+bagstore-service.base-url=http://localhost:20110/
+bagstore-service.connection-timeout-milliseconds=5000
+bagstore-service.read-timeout-milliseconds=5000

--- a/command/src/main/assembly/dist/cfg/application.properties
+++ b/command/src/main/assembly/dist/cfg/application.properties
@@ -17,6 +17,3 @@
 tempdir=/var/opt/dans.knaw.nl/tmp/easy-archive-bag-staging
 bag-index.uri=http://localhost:20120/
 
-bagstore-service.base-url=http://localhost:20110/
-bagstore-service.connection-timeout-milliseconds=5000
-bagstore-service.read-timeout-milliseconds=5000

--- a/command/src/main/assembly/dist/cfg/application.properties
+++ b/command/src/main/assembly/dist/cfg/application.properties
@@ -16,4 +16,3 @@
 
 tempdir=/var/opt/dans.knaw.nl/tmp/easy-archive-bag-staging
 bag-index.uri=http://localhost:20120/
-

--- a/command/src/main/scala/nl.knaw.dans.easy.archivebag.command/Command.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.archivebag.command/Command.scala
@@ -15,9 +15,8 @@
  */
 package nl.knaw.dans.easy.archivebag.command
 
+import nl.knaw.dans.easy.archivebag.{ EasyArchiveBag, Parameters }
 import nl.knaw.dans.lib.error._
-
-import nl.knaw.dans.easy.archivebag.{Parameters, EasyArchiveBag}
 
 object Command {
 

--- a/command/src/main/scala/nl.knaw.dans.easy.archivebag.command/CommandLineOptions.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.archivebag.command/CommandLineOptions.scala
@@ -42,10 +42,7 @@ object CommandLineOptions extends DebugEnhancedLogging {
       storageDepositService = cmd.bagStoreUrl(),
       bagIndexService = new URI(configuration.properties.getString("bag-index.uri")),
       bagId = cmd.uuid(),
-      userAgent = s"easy-archive-bag/${ configuration.version }",
-      bagStoreBaseUrl = new URI(configuration.properties.getString("bagstore-service.base-url")),
-      connectionTimeoutMs = configuration.properties.getInt("bagstore-service.connection-timeout-milliseconds", 1000),
-      readTimeoutMs = configuration.properties.getInt("bagstore-service.read-timeout-milliseconds", 5000),
+      userAgent = s"easy-archive-bag/${ configuration.version }"
     )
 
     debug(s"Using the following settings: $settings")

--- a/command/src/main/scala/nl.knaw.dans.easy.archivebag.command/CommandLineOptions.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.archivebag.command/CommandLineOptions.scala
@@ -43,6 +43,9 @@ object CommandLineOptions extends DebugEnhancedLogging {
       bagIndexService = new URI(configuration.properties.getString("bag-index.uri")),
       bagId = cmd.uuid(),
       userAgent = s"easy-archive-bag/${ configuration.version }",
+      bagStoreBaseUrl = new URI(configuration.properties.getString("bagstore-service.base-url")),
+      connectionTimeoutMs = configuration.properties.getInt("bagstore-service.connection-timeout-milliseconds", 1000),
+      readTimeoutMs = configuration.properties.getInt("bagstore-service.read-timeout-milliseconds", 5000),
     )
 
     debug(s"Using the following settings: $settings")

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,15 +9,21 @@ SYNOPSIS
 --------
 
     easy-archive-bag [--user|-u <user>][--password,-p <password] \
-                       <bag-directory> <uuid> [<bag-store-service-url>]
+                       <bag-directory> <uuid> <bag-store-service-url>
 
 
 DESCRIPTION
 -----------
 
 Takes a directory in BagIt format, zips it and sends it via an HTTP `PUT` request to 
-`bag-store-url/<uuid>`. If the `bag-info.txt` contains an entry `Is-Version-Of` the
-value must be a valid bag-id. Note that the `bag-store-url` only contains the base
+`bag-store-url/<uuid>`. 
+
+If the `bag-info.txt` contains an entry `Is-Version-Of`:
+  * the value must be a valid bag-id
+  * the `EASY-User-Account` in the referred bag has to be the same as current user
+  * the referred bag has to be in the store as the new bag
+  
+Note that the `bag-store-url` only contains the base
 URL of the bag store, e.g. `http://myarchive/bagstores/mybagstore`.
 
 

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.archivebag
 
 import java.net.{ URI, URL }

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
@@ -1,0 +1,76 @@
+package nl.knaw.dans.easy.archivebag
+
+import java.net.{ URI, URL }
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import scalaj.http.{ Http, HttpResponse }
+
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * Simple, incomplete interface to the bag store service that provides methods:
+ *  - to read the bag info.txt
+ *  - to check existence of a bag in a specific bagstore
+ */
+trait BagStore extends DebugEnhancedLogging {
+  val bagStoreBaseUrl: URI
+  val connectionTimeoutMs: Int
+  val readTimeoutMs: Int
+
+  /**
+   * Fetches bag info.txt for a given UUID.
+   *
+   * @param bagId the bag-id of the bag
+   * @return bag info.txt
+   */
+  def getBagInfoText(bagId: BagId): Try[String] = {
+    val url = bagStoreBaseUrl.resolve(s"bags/$bagId/bag-info.txt").toASCIIString
+    debug(s"calling $url")
+
+    Try {
+      Http(url)
+        .timeout(connTimeoutMs = connectionTimeoutMs, readTimeoutMs = readTimeoutMs)
+        .asString
+    }
+      .flatMap {
+      case HttpResponse(body, 200, _) =>
+        Success(body)
+      case HttpResponse(body, code, _) =>
+        logger.error(s"call to $url failed: $code - $body")
+        Failure(BagStoreException(url, code))
+    }
+  }
+
+  /**
+   * Checks existence of bag info.txt for a given UUID.
+   *
+   * @param storeUrl url to the store where to look for the bag
+   * @param bagId    the bag-id of the bag
+   * @return boolean
+   */
+  def bagExists(storeUrl: URL, bagId: BagId): Try[Boolean] = {
+    trace(bagId)
+    val bagUrl = storeUrl.toURI.resolve(s"$bagId").toASCIIString
+    debug(s"Requesting: $bagUrl")
+    Try {
+      Http(bagUrl)
+        .header("Accept", "text/plain")
+        .timeout(connTimeoutMs = connectionTimeoutMs, readTimeoutMs = readTimeoutMs)
+        .method("HEAD")
+        .asBytes.code
+    }
+      .flatMap {
+        case code if (code == 200 || code == 201) => Success(true)
+        case code if (code == 404) => Success(false)
+        case code: Int => Failure(new Exception(s"Reading from store $storeUrl failed, HTTP code: $code"))
+      }
+  }
+}
+
+object BagStore {
+  def apply(baseUrl: URI, cto: Int, rto: Int): BagStore = new BagStore() {
+    override val bagStoreBaseUrl: URI = baseUrl
+    override val connectionTimeoutMs: Int = cto
+    override val readTimeoutMs: Int = rto
+  }
+}

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
@@ -33,12 +33,12 @@ trait BagStore extends DebugEnhancedLogging {
         .asString
     }
       .flatMap {
-      case HttpResponse(body, 200, _) =>
-        Success(body)
-      case HttpResponse(body, code, _) =>
-        logger.error(s"call to $url failed: $code - $body")
-        Failure(BagStoreException(url, code))
-    }
+        case HttpResponse(body, 200, _) =>
+          Success(body)
+        case HttpResponse(body, code, _) =>
+          logger.error(s"call to $url failed: $code - $body")
+          Failure(BagStoreException(url, code))
+      }
   }
 
   /**

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagStore.scala
@@ -57,7 +57,7 @@ trait BagStore extends DebugEnhancedLogging {
   }
 
   /**
-   * Checks existence of bag info.txt for a given UUID.
+   * Checks existence of a bag for a given UUID in a given store.
    *
    * @param storeUrl url to the store where to look for the bag
    * @param bagId    the bag-id of the bag
@@ -65,7 +65,7 @@ trait BagStore extends DebugEnhancedLogging {
    */
   def bagExists(storeUrl: URL, bagId: BagId): Try[Boolean] = {
     trace(bagId)
-    val bagUrl = storeUrl.toURI.resolve(s"$bagId").toASCIIString
+    val bagUrl = storeUrl.toURI.resolve(s"bags/$bagId").toASCIIString
     debug(s"Requesting: $bagUrl")
     Try {
       Http(bagUrl)

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
@@ -36,6 +36,8 @@ trait BagFacadeComponent {
   val bagFacade: BagFacade
 
   val IS_VERSION_OF_KEY = "Is-Version-Of"
+  val EASY_USER_ACCOUNT = "EASY-User-Account"
+
 
   trait BagFacade {
     def getIsVersionOf(bagDir: Path): Try[Option[BagId]]

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/BagitFacadeComponent.scala
@@ -34,10 +34,7 @@ import scala.util.{ Failure, Success, Try }
 trait BagFacadeComponent {
 
   val bagFacade: BagFacade
-
   val IS_VERSION_OF_KEY = "Is-Version-Of"
-  val EASY_USER_ACCOUNT = "EASY-User-Account"
-
 
   trait BagFacade {
     def getIsVersionOf(bagDir: Path): Try[Option[BagId]]

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -102,7 +102,7 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
                 location
             })
       case 401 =>
-        Failure(UnautherizedException(ps.bagId))
+        Failure(UnauthorizedException(ps.bagId))
       case _ =>
         logger.error(s"${ ps.storageDepositService } returned:[ ${ response.statusLine } ]. Body = ${ response.body }")
         Failure(new RuntimeException(s"Bag archiving failed: ${ response.statusLine }"))

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/EasyArchiveBag.scala
@@ -51,7 +51,7 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
   }
 
   private def handleIsVersionOf(versionOfId: BagId)(implicit ps: Parameters): Try[Unit] = {
-    val bagStore: BagStore = BagStore(ps.bagStoreBaseUrl, ps.connectionTimeoutMs, ps.readTimeoutMs)
+    val bagStore: BagStore = BagStore(ps.storageDepositService)
     for {
       _ <- checkSameUser(bagStore, versionOfId)
       _ <- checkSameStore(bagStore, versionOfId)
@@ -88,7 +88,7 @@ object EasyArchiveBag extends Bagit5FacadeComponent with DebugEnhancedLogging {
   }
 
   private def checkSameStore(bagStore: BagStore, versionOfId: BagId)(implicit ps: Parameters): Try[Boolean] = {
-    val exists = bagStore.bagExists(ps.storageDepositService, versionOfId)
+    val exists = bagStore.bagExists(versionOfId)
     if (exists.filter(_ == false).isSuccess)
       Failure(DifferentStoreException(ps.storageDepositService, versionOfId))
     else

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
@@ -41,7 +41,7 @@ package object archivebag {
                         storageDepositService: URL,
                         bagIndexService: URI,
                         bagId: BagId,
-                        userAgent: String
+                        userAgent: String,
                        ) {
     lazy val http = new BaseHttp(
       userAgent = userAgent,
@@ -50,8 +50,6 @@ package object archivebag {
         HttpOptions.followRedirects(false),
       ))
   }
-
-  case class BagFile(path: Path, checksum: String)
 
   implicit def bagId(implicit ps: Parameters): BagId = ps.bagId
 

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
@@ -27,7 +27,7 @@ package object archivebag {
   case class BagReaderException(bagDir: Path, cause: Throwable) extends Exception(s"The bag at '$bagDir' could not be read: ${ cause.getMessage }", cause)
   case class BagStoreException(url: String, code: Int) extends Exception(s"Could not be read from bagstore, at '$url' (code: $code)")
   case class InvalidIsVersionOfException(value: String) extends Exception(s"Unsupported value in the bag-info.txt field Is-Version-Of: $value")
-  case class DifferentUserException(user: String, userReferredBag: String, versionOfId: BagId) extends Exception(s"User $user is different from the user $userReferredBag in isVersionOfBag $versionOfId")
+  case class DifferentUserException(user: String, userReferredBag: String, versionOfId: BagId) extends Exception(s"User $user is different from the user $userReferredBag in bag $versionOfId")
   case class DifferentStoreException(storeUrl: URL, versionOfId: BagId) extends Exception(s"IsVersionOf bag $versionOfId is not in the same store $storeUrl as the bag that refers to it")
   case class NoUserException(versionOfId: BagId) extends Exception(s"No user found for isVersionOfBag $versionOfId")
   case class UnauthorizedException(bagId: BagId) extends Exception(s"No or invalid credentials provided for storage deposit service while depositing bag $bagId")

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
@@ -41,10 +41,7 @@ package object archivebag {
                         storageDepositService: URL,
                         bagIndexService: URI,
                         bagId: BagId,
-                        userAgent: String,
-                        bagStoreBaseUrl: URI,
-                        connectionTimeoutMs: Int,
-                        readTimeoutMs: Int
+                        userAgent: String
                        ) {
     lazy val http = new BaseHttp(
       userAgent = userAgent,

--- a/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.archivebag/package.scala
@@ -30,7 +30,7 @@ package object archivebag {
   case class DifferentUserException(user: String, userReferredBag: String, versionOfId: BagId) extends Exception(s"User $user is different from the user $userReferredBag in isVersionOfBag $versionOfId")
   case class DifferentStoreException(storeUrl: URL, versionOfId: BagId) extends Exception(s"IsVersionOf bag $versionOfId is not in the same store $storeUrl as the bag that refers to it")
   case class NoUserException(versionOfId: BagId) extends Exception(s"No user found for isVersionOfBag $versionOfId")
-  case class UnautherizedException(bagId: BagId) extends Exception(s"No or invalid credentials provided for storage deposit service while depositing bag $bagId")
+  case class UnauthorizedException(bagId: BagId) extends Exception(s"No or invalid credentials provided for storage deposit service while depositing bag $bagId")
 
   type BagId = UUID
 
@@ -57,5 +57,6 @@ package object archivebag {
   case class BagFile(path: Path, checksum: String)
 
   implicit def bagId(implicit ps: Parameters): BagId = ps.bagId
+
   implicit def tempDir(implicit ps: Parameters): File = ps.tempDir
 }

--- a/lib/src/test/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBagSpec.scala
+++ b/lib/src/test/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBagSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.archivebag
 
 import java.util.UUID

--- a/lib/src/test/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBagSpec.scala
+++ b/lib/src/test/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBagSpec.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.archivebag
 
 import java.util.UUID
 
-import nl.knaw.dans.easy.archivebag.EasyArchiveBag.{ getUser, getUserLines }
+import nl.knaw.dans.easy.archivebag.EasyArchiveBag.{ getReferredBagUser, getUserLines }
 import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -35,11 +35,11 @@ class EasyArchiveBagSpec extends AnyFlatSpec with Matchers with Inside {
     "Bagging-Date: 2019-05-23\nBag-Size: 3.1 MB\n" +
     "Created: 2016-11-12T23:41:11.000+00:00\n"
 
-  "getUser" should "return the correct user" in {
-    getUser(bagId, getUserLines(infoText)).get shouldBe "user001"
+  "getReferredBagUser" should "return the correct user" in {
+    getReferredBagUser(bagId, getUserLines(infoText)).get shouldBe "user001"
   }
 
   it should "fail when there is no user account given in the info.txt" in {
-    getUser(bagId, getUserLines(infoTextNoUser)) should matchPattern { case Failure(NoUserException(`bagId`)) => }
+    getReferredBagUser(bagId, getUserLines(infoTextNoUser)) should matchPattern { case Failure(NoUserException(`bagId`)) => }
   }
 }

--- a/lib/src/test/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBagSpec.scala
+++ b/lib/src/test/scala/nl/knaw/dans/easy/archivebag/EasyArchiveBagSpec.scala
@@ -1,0 +1,30 @@
+package nl.knaw.dans.easy.archivebag
+
+import java.util.UUID
+
+import nl.knaw.dans.easy.archivebag.EasyArchiveBag.{ getUser, getUserLines }
+import org.scalatest.Inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Failure
+
+class EasyArchiveBagSpec extends AnyFlatSpec with Matchers with Inside {
+
+  private val bagId = UUID.randomUUID()
+  private val infoText = "Payload-Oxum: 3212481.4\n" +
+    "Bagging-Date: 2019-05-23\nBag-Size: 3.1 MB\n" +
+    "Created: 2016-11-12T23:41:11.000+00:00\n" +
+    "EASY-User-Account: user001"
+  private val infoTextNoUser = "Payload-Oxum: 3212481.4\n" +
+    "Bagging-Date: 2019-05-23\nBag-Size: 3.1 MB\n" +
+    "Created: 2016-11-12T23:41:11.000+00:00\n"
+
+  "getUser" should "return the correct user" in {
+    getUser(bagId, getUserLines(infoText)).get shouldBe "user001"
+  }
+
+  it should "fail when there is no user account given in the info.txt" in {
+    getUser(bagId, getUserLines(infoTextNoUser)) should matchPattern { case Failure(NoUserException(`bagId`)) => }
+  }
+}


### PR DESCRIPTION
fixes EASY-2050

#### When applied it will, when the bag is a version of another bag
* check that the `user` is the same as in the referred bag
* check that the `store` is the same as for the referred bag


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
